### PR TITLE
chore: add license

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ Single file, web-based, Bible application designed for offline use.
 - Allows for side loading on a device without any warnings.
 - Give people the plan of salvation.
 - Educate people on how cell phones are used for tracking.
-- Copyright free.
 
 ## Contributing
 
 Thank you for considering contributing to the Sinim Bible App.
 All the information you need to get started is in the [CONTRIBUTING.md](CONTRIBUTING.md) file.
+
+## License
+
+This is free and unencumbered software released into the public domain.
+See the [UNLICENSE](UNLICENSE) file for details.

--- a/UNLICENSE
+++ b/UNLICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Sinim Bible App",
   "author": "//",
   "type": "module",
-  "license": "//",
+  "license": "Unlicense",
   "dependencies": {
     "@heroicons/vue": "^2.1.3",
     "@vueuse/core": "^10.9.0",


### PR DESCRIPTION
Hello!

This PR adds an explicit license (as repositories without a license are considered fully copy-written) which releases this software into the public domain.

If you'd rather use another license just let me know. I went with the [The Unlicense](https://choosealicense.com/licenses/unlicense), as I felt that was best for this software, but some other popular choices are [MIT](https://choosealicense.com/licenses/mit) and [ISC](https://choosealicense.com/licenses/isc) which maintain the copyright but grant full permission to use however is desired.

Thanks!